### PR TITLE
feat: Add AWS S3 presigned URL upload for identity documents

### DIFF
--- a/app/Config/Aws.php
+++ b/app/Config/Aws.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+/**
+ * AWS Configuration
+ */
+class Aws extends BaseConfig
+{
+    public string $accessKey = '';
+    public string $secretKey = '';
+    public string $region = 'ap-south-1';
+    public string $bucketName = '';
+
+    // Presigned URL expiry in minutes
+    public int $presignedUrlExpiry = 15;
+
+    // S3 path prefixes for different file types
+    public string $documentsPrefix = 'documents';
+    public string $videosPrefix = 'videos';
+    public string $certificatesPrefix = 'certificates';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Load from environment
+        $this->accessKey = env('AWS_ACCESS_KEY_ID', '');
+        $this->secretKey = env('AWS_SECRET_ACCESS_KEY', '');
+        $this->region = env('AWS_REGION', $this->region);
+        $this->bucketName = env('AWS_BUCKET', '');
+    }
+}

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -51,6 +51,10 @@ $routes->group('', ['filter' => ['session', 'group:user']], static function ($ro
     $routes->get('identity-upload', 'UserController::identityUpload');
     $routes->post('identity-upload', 'UserController::processIdentityUpload');
 
+    // API endpoints for S3 presigned upload
+    $routes->post('api/get-upload-url', 'UserController::apiGetUploadUrl');
+    $routes->post('api/confirm-upload', 'UserController::apiConfirmUpload');
+
     // Verification Status (accessible during auth flow)
     $routes->get('verification-status', 'UserController::verificationStatus');
 });

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -19,14 +19,16 @@ use CodeIgniter\Config\BaseService;
  */
 class Services extends BaseService
 {
-    /*
-     * public static function example($getShared = true)
-     * {
-     *     if ($getShared) {
-     *         return static::getSharedInstance('example');
-     *     }
-     *
-     *     return new \CodeIgniter\Example();
-     * }
+    /**
+     * S3 Storage Service
+     * Usage: service('s3')->upload($file, 'path')
      */
+    public static function s3(bool $getShared = true): \App\Services\S3Service
+    {
+        if ($getShared) {
+            return static::getSharedInstance('s3');
+        }
+
+        return new \App\Services\S3Service();
+    }
 }

--- a/app/Models/UserDocumentModel.php
+++ b/app/Models/UserDocumentModel.php
@@ -169,4 +169,20 @@ class UserDocumentModel extends Model
     {
         return $this->where('status', 'PENDING')->countAllResults();
     }
+
+    /**
+     * Check if Aadhaar number is already in use by another user
+     * Only checks PENDING or APPROVED documents
+     * 
+     * @param string $aadharNumber The Aadhaar number to check
+     * @param int $excludeUserId The current user to exclude from check
+     * @return bool True if Aadhaar is already in use by another user
+     */
+    public function isAadhaarInUse(string $aadharNumber, int $excludeUserId): bool
+    {
+        return $this->where('aadhar_number', $aadharNumber)
+            ->where('user_id !=', $excludeUserId)
+            ->whereIn('status', ['PENDING', 'APPROVED'])
+            ->countAllResults() > 0;
+    }
 }

--- a/app/Services/S3Service.php
+++ b/app/Services/S3Service.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Services;
+
+use Aws\S3\S3Client;
+use Aws\S3\Exception\S3Exception;
+use CodeIgniter\HTTP\Files\UploadedFile;
+use Config\Aws;
+
+/**
+ * S3 Service for file storage operations
+ * 
+ * Usage:
+ *   $s3 = service('s3');
+ *   $url = $s3->upload($file, 'documents/' . $userId);
+ *   $presignedUrl = $s3->getPresignedUrl($key);
+ */
+class S3Service
+{
+    protected S3Client $client;
+    protected Aws $config;
+
+    public function __construct()
+    {
+        $this->config = config('Aws');
+
+        // Validate required config
+        if (empty($this->config->accessKey) || empty($this->config->secretKey) || empty($this->config->bucketName)) {
+            throw new \RuntimeException('AWS configuration is incomplete. Please set aws.accessKey, aws.secretKey, and aws.bucketName in your .env file.');
+        }
+
+        $this->client = new S3Client([
+            'version' => 'latest',
+            'region' => $this->config->region,
+            'credentials' => [
+                'key' => $this->config->accessKey,
+                'secret' => $this->config->secretKey,
+            ],
+        ]);
+    }
+
+    /**
+     * Upload a file to S3
+     * 
+     * @param UploadedFile $file The uploaded file
+     * @param string $path Folder path in S3 (e.g., 'documents/123')
+     * @return array ['success' => bool, 'key' => string, 'url' => string, 'error' => string]
+     */
+    public function upload(UploadedFile $file, string $path): array
+    {
+        try {
+            // Generate unique filename: timestamp_uniqid.extension
+            $extension = $file->getClientExtension();
+            $filename = time() . '_' . uniqid() . '.' . $extension;
+            $key = trim($path, '/') . '/' . $filename;
+
+            // Upload to S3
+            $result = $this->client->putObject([
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+                'Body' => fopen($file->getTempName(), 'rb'),
+                'ContentType' => $file->getMimeType(),
+            ]);
+
+            return [
+                'success' => true,
+                'key' => $key,
+                'url' => $result['ObjectURL'] ?? '',
+                'error' => null,
+            ];
+        } catch (S3Exception $e) {
+            log_message('error', 'S3 Upload Error: ' . $e->getMessage());
+            return [
+                'success' => false,
+                'key' => null,
+                'url' => null,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Upload raw content to S3 (for videos, etc.)
+     * 
+     * @param string $content File content
+     * @param string $key Full S3 key (path + filename)
+     * @param string $contentType MIME type
+     * @return array
+     */
+    public function uploadContent(string $content, string $key, string $contentType): array
+    {
+        try {
+            $result = $this->client->putObject([
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+                'Body' => $content,
+                'ContentType' => $contentType,
+            ]);
+
+            return [
+                'success' => true,
+                'key' => $key,
+                'url' => $result['ObjectURL'] ?? '',
+                'error' => null,
+            ];
+        } catch (S3Exception $e) {
+            log_message('error', 'S3 Upload Error: ' . $e->getMessage());
+            return [
+                'success' => false,
+                'key' => null,
+                'url' => null,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Get a presigned URL for private file access (GET)
+     * 
+     * @param string $key S3 object key
+     * @param int|null $expiryMinutes URL expiry in minutes (default from config)
+     * @return string|null Presigned URL or null on error
+     */
+    public function getPresignedUrl(string $key, ?int $expiryMinutes = null): ?string
+    {
+        try {
+            $expiry = $expiryMinutes ?? $this->config->presignedUrlExpiry;
+
+            $command = $this->client->getCommand('GetObject', [
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+            ]);
+
+            $presignedRequest = $this->client->createPresignedRequest(
+                $command,
+                "+{$expiry} minutes"
+            );
+
+            return (string) $presignedRequest->getUri();
+        } catch (S3Exception $e) {
+            log_message('error', 'S3 Presigned URL Error: ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Get a presigned URL for direct file upload (PUT)
+     * 
+     * Frontend uploads directly to S3 using this URL
+     * 
+     * @param string $path Folder path (e.g., 'documents/123')
+     * @param string $filename Desired filename
+     * @param string $contentType MIME type of file
+     * @param int|null $expiryMinutes URL expiry in minutes
+     * @return array ['success' => bool, 'uploadUrl' => string, 'key' => string]
+     */
+    public function getPresignedUploadUrl(string $path, string $filename, string $contentType, ?int $expiryMinutes = null): array
+    {
+        try {
+            $expiry = $expiryMinutes ?? 5; // 5 minutes for upload
+            $key = trim($path, '/') . '/' . $filename;
+
+            $command = $this->client->getCommand('PutObject', [
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+                'ContentType' => $contentType,
+            ]);
+
+            $presignedRequest = $this->client->createPresignedRequest(
+                $command,
+                "+{$expiry} minutes"
+            );
+
+            return [
+                'success' => true,
+                'uploadUrl' => (string) $presignedRequest->getUri(),
+                'key' => $key,
+                'error' => null,
+            ];
+        } catch (S3Exception $e) {
+            log_message('error', 'S3 Presigned Upload URL Error: ' . $e->getMessage());
+            return [
+                'success' => false,
+                'uploadUrl' => null,
+                'key' => null,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Generate a unique filename
+     * 
+     * @param string $extension File extension
+     * @return string
+     */
+    public function generateFilename(string $extension): string
+    {
+        return time() . '_' . uniqid() . '.' . strtolower($extension);
+    }
+
+    /**
+     * Delete a file from S3
+     * 
+     * @param string $key S3 object key
+     * @return bool Success status
+     */
+    public function delete(string $key): bool
+    {
+        try {
+            $this->client->deleteObject([
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+            ]);
+            return true;
+        } catch (S3Exception $e) {
+            log_message('error', 'S3 Delete Error: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Check if a file exists in S3
+     * 
+     * @param string $key S3 object key
+     * @return bool
+     */
+    public function exists(string $key): bool
+    {
+        try {
+            return $this->client->doesObjectExist($this->config->bucketName, $key);
+        } catch (S3Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get file metadata
+     * 
+     * @param string $key S3 object key
+     * @return array|null
+     */
+    public function getMetadata(string $key): ?array
+    {
+        try {
+            $result = $this->client->headObject([
+                'Bucket' => $this->config->bucketName,
+                'Key' => $key,
+            ]);
+
+            return [
+                'size' => $result['ContentLength'] ?? 0,
+                'contentType' => $result['ContentType'] ?? '',
+                'lastModified' => $result['LastModified'] ?? null,
+            ];
+        } catch (S3Exception $e) {
+            return null;
+        }
+    }
+}

--- a/app/Views/user/identity_upload.php
+++ b/app/Views/user/identity_upload.php
@@ -23,10 +23,12 @@
                 </div>
             </div>
 
-            <form id="identityUploadForm" action="/identity-upload" method="post" enctype="multipart/form-data">
+            <form id="identityUploadForm" data-no-protect="true">
+                <input type="hidden" name="<?= csrf_token() ?>" value="<?= csrf_hash() ?>" id="csrfToken">
+
                 <div class="form-group">
                     <label class="form-label">Aadhar Number <span class="required">*</span></label>
-                    <input type="text" name="aadhar_number" class="form-control"
+                    <input type="text" name="aadhar_number" id="aadharNumber" class="form-control"
                         placeholder="Enter 12-digit Aadhar number"
                         pattern="[0-9]{12}"
                         maxlength="12"
@@ -36,8 +38,8 @@
 
                 <div class="form-group">
                     <label class="form-label">Upload Aadhar Card <span class="required">*</span></label>
+                    <input type="file" name="document" id="documentFile" accept=".pdf,.jpg,.jpeg,.png" hidden required>
                     <div class="file-upload" id="fileUploadArea">
-                        <input type="file" name="document" id="documentFile" accept=".pdf,.jpg,.jpeg,.png" hidden required>
                         <i class="bi bi-cloud-arrow-up"></i>
                         <p class="mb-1">Click or drag file to upload</p>
                         <span>Supported formats: PDF, JPG, PNG (Max: 5MB)</span>
@@ -45,7 +47,7 @@
                     <div id="filePreview" class="mt-3 d-none">
                         <div class="d-flex align-items-center justify-content-between p-3 bg-light rounded">
                             <div class="d-flex align-items-center gap-3">
-                                <i class="bi bi-file-earmark-pdf text-danger" style="font-size: 32px;"></i>
+                                <i class="bi bi-file-earmark-pdf text-danger" style="font-size: 32px;" id="fileIcon"></i>
                                 <div>
                                     <p class="mb-0 fw-bold" id="fileName">document.pdf</p>
                                     <small class="text-muted" id="fileSize">2.5 MB</small>
@@ -54,6 +56,17 @@
                             <button type="button" class="btn btn-sm btn-outline-danger" id="removeFile">
                                 <i class="bi bi-x"></i> Remove
                             </button>
+                        </div>
+                    </div>
+
+                    <!-- Upload Progress -->
+                    <div id="uploadProgress" class="mt-3 d-none">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <span id="uploadStatusText">Uploading...</span>
+                            <span id="uploadPercent">0%</span>
+                        </div>
+                        <div class="progress" style="height: 8px;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated" id="progressBar" style="width: 0%"></div>
                         </div>
                     </div>
                 </div>
@@ -68,7 +81,7 @@
                 </div>
 
                 <div class="d-grid gap-2">
-                    <button type="submit" class="btn btn-primary btn-lg">
+                    <button type="submit" class="btn btn-primary btn-lg" id="submitBtn">
                         <i class="bi bi-upload"></i> Submit for Verification
                     </button>
                     <a href="/dashboard" class="btn btn-outline-secondary">Cancel</a>
@@ -80,25 +93,5 @@
 <?= $this->endSection() ?>
 
 <?= $this->section('scripts') ?>
-<script>
-    const fileInput = document.getElementById('documentFile');
-    const fileUploadArea = document.getElementById('fileUploadArea');
-    const filePreview = document.getElementById('filePreview');
-
-    fileInput.addEventListener('change', function() {
-        if (this.files.length > 0) {
-            const file = this.files[0];
-            document.getElementById('fileName').textContent = file.name;
-            document.getElementById('fileSize').textContent = (file.size / 1024 / 1024).toFixed(2) + ' MB';
-            filePreview.classList.remove('d-none');
-            fileUploadArea.style.display = 'none';
-        }
-    });
-
-    document.getElementById('removeFile').addEventListener('click', function() {
-        fileInput.value = '';
-        filePreview.classList.add('d-none');
-        fileUploadArea.style.display = 'block';
-    });
-</script>
+<script src="/assets/js/identity-upload.js"></script>
 <?= $this->endSection() ?>

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "require": {
         "php": "^8.1",
+        "aws/aws-sdk-php": "^3.369",
         "codeigniter4/framework": "^4.0",
         "codeigniter4/shield": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae76446c85de95859dc95f389c7553b2",
+    "content-hash": "dabe74a1b6e7be2d976cdff3c32185bc",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.369.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "36ee8894743a254ae2650bad4968c874b76bc7de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/36ee8894743a254ae2650bad4968c874b76bc7de",
+                "reference": "36ee8894743a254ae2650bad4968c874b76bc7de",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^9.6",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.369.12"
+            },
+            "time": "2026-01-13T19:12:08+00:00"
+        },
         {
             "name": "codeigniter4/framework",
             "version": "v4.6.4",
@@ -207,6 +358,331 @@
             "time": "2025-07-14T10:26:03+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T22:36:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-22T14:34:08+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "21dc724a0583619cd1652f673303492272778051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T21:21:41+00:00"
+        },
+        {
             "name": "laminas/laminas-escaper",
             "version": "2.18.0",
             "source": {
@@ -268,6 +744,232 @@
             "time": "2025-10-14T18:31:13+00:00"
         },
         {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+            },
+            "time": "2024-09-04T18:46:31+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -316,6 +1018,355 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d937d400b980523dc9ee946bb69972b5e619058d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d937d400b980523dc9ee946bb69972b5e619058d",
+                "reference": "d937d400b980523dc9ee946bb69972b5e619058d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-01T09:13:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
         }
     ],
     "packages-dev": [
@@ -2105,73 +3156,6 @@
                 }
             ],
             "time": "2023-02-07T11:34:05+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/env
+++ b/env
@@ -79,3 +79,10 @@
 # email.SMTPPort  = 
 # email.SMTPCrypto = 
 # email.mailType  = 
+
+# AWS Configuration
+# AWS_ACCESS_KEY_ID = 
+# AWS_SECRET_ACCESS_KEY = 
+# AWS_REGION = ap-south-1
+# AWS_BUCKET = m2w-ollms
+

--- a/public/assets/js/identity-upload.js
+++ b/public/assets/js/identity-upload.js
@@ -1,0 +1,150 @@
+/**
+ * Identity Upload Handler
+ * Handles direct S3 upload with presigned URLs
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('identityUploadForm');
+    if (!form) return;
+
+    const fileInput = document.getElementById('documentFile');
+    const fileUploadArea = document.getElementById('fileUploadArea');
+    const filePreview = document.getElementById('filePreview');
+    const uploadProgress = document.getElementById('uploadProgress');
+    const progressBar = document.getElementById('progressBar');
+    const uploadPercent = document.getElementById('uploadPercent');
+    const uploadStatusText = document.getElementById('uploadStatusText');
+    const submitBtn = document.getElementById('submitBtn');
+    const csrfToken = document.getElementById('csrfToken').value;
+    const csrfName = document.getElementById('csrfToken').name;
+
+    // File selection
+    fileUploadArea.addEventListener('click', () => fileInput.click());
+
+    fileInput.addEventListener('change', function () {
+        if (this.files.length > 0) {
+            const file = this.files[0];
+            document.getElementById('fileName').textContent = file.name;
+            document.getElementById('fileSize').textContent = (file.size / 1024 / 1024).toFixed(2) + ' MB';
+
+            // Update icon based on file type
+            const fileIcon = document.getElementById('fileIcon');
+            if (file.type === 'application/pdf') {
+                fileIcon.className = 'bi bi-file-earmark-pdf text-danger';
+            } else {
+                fileIcon.className = 'bi bi-file-earmark-image text-primary';
+            }
+
+            filePreview.classList.remove('d-none');
+            fileUploadArea.style.display = 'none';
+        }
+    });
+
+    document.getElementById('removeFile').addEventListener('click', function () {
+        fileInput.value = '';
+        filePreview.classList.add('d-none');
+        fileUploadArea.style.display = 'block';
+    });
+
+    // Form submission with presigned URL upload
+    form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+
+        const aadharNumber = document.getElementById('aadharNumber').value.replace(/\s/g, '');
+        const file = fileInput.files[0];
+        const declaration = document.getElementById('declaration').checked;
+
+        // Validations
+        if (!/^\d{12}$/.test(aadharNumber)) {
+            SwalHelper.error('Invalid Aadhar', 'Please enter a valid 12-digit Aadhar number.');
+            return;
+        }
+
+        if (!file) {
+            SwalHelper.error('No File', 'Please select a document to upload.');
+            return;
+        }
+
+        if (!declaration) {
+            SwalHelper.error('Declaration Required', 'Please accept the declaration to proceed.');
+            return;
+        }
+
+        // Disable button and show progress
+        submitBtn.disabled = true;
+        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Processing...';
+        uploadProgress.classList.remove('d-none');
+
+        try {
+            // Step 1: Get presigned upload URL
+            updateProgress(10, 'Getting upload URL...');
+
+            const formData = new FormData();
+            formData.append(csrfName, csrfToken);
+            formData.append('aadhar_number', aadharNumber);
+            formData.append('filename', file.name);
+            formData.append('content_type', file.type);
+            formData.append('file_size', file.size);
+
+            const urlResponse = await axios.post('/api/get-upload-url', formData);
+
+            if (!urlResponse.data.success) {
+                throw new Error(urlResponse.data.message || 'Failed to get upload URL');
+            }
+
+            const { uploadUrl, key } = urlResponse.data.data;
+
+            // Step 2: Upload directly to S3
+            updateProgress(20, 'Uploading to cloud...');
+
+            await axios.put(uploadUrl, file, {
+                headers: {
+                    'Content-Type': file.type,
+                },
+                onUploadProgress: (progressEvent) => {
+                    const percent = Math.round((progressEvent.loaded * 60 / progressEvent.total) + 20);
+                    updateProgress(percent, 'Uploading to cloud...');
+                }
+            });
+
+            // Step 3: Confirm upload with server
+            updateProgress(85, 'Confirming upload...');
+
+            const confirmData = new FormData();
+            confirmData.append(csrfName, csrfToken);
+
+            const confirmResponse = await axios.post('/api/confirm-upload', confirmData);
+
+            if (!confirmResponse.data.success) {
+                throw new Error(confirmResponse.data.message || 'Failed to confirm upload');
+            }
+
+            updateProgress(100, 'Complete!');
+
+            // Success
+            SwalHelper.success('Success', confirmResponse.data.message).then(() => {
+                if (confirmResponse.data.data?.redirect) {
+                    window.location.href = confirmResponse.data.data.redirect;
+                }
+            });
+
+        } catch (error) {
+            console.error('Upload error:', error);
+            const message = error.response?.data?.message || error.message || 'Upload failed. Please try again.';
+            SwalHelper.error('Upload Failed', message);
+            resetForm();
+        }
+    });
+
+    function updateProgress(percent, text) {
+        progressBar.style.width = percent + '%';
+        uploadPercent.textContent = percent + '%';
+        uploadStatusText.textContent = text;
+    }
+
+    function resetForm() {
+        submitBtn.disabled = false;
+        submitBtn.innerHTML = '<i class="bi bi-upload"></i> Submit for Verification';
+        uploadProgress.classList.add('d-none');
+        progressBar.style.width = '0%';
+    }
+});


### PR DESCRIPTION
feat: Add AWS S3 integration for document uploads

- Created S3Service with presigned URL upload flow
- Added Aws config for S3 credentials and path prefixes
- Implemented direct browser-to-S3 upload with progress bar
- Created identity-upload.js for cleaner code organization

API endpoints:
- POST /api/get-upload-url - Get presigned upload URL
- POST /api/confirm-upload - Confirm upload after S3 transfer

Files:
- app/Config/Aws.php (new)
- app/Services/S3Service.php (new)
- public/assets/js/identity-upload.js (new)
